### PR TITLE
Show red shadow when drag n drop is prevented by maxDepth

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -90,13 +90,13 @@ const NodeRendererDefault = ({
                 </div>
             )}
 
-            <div className={styles.rowWrapper}>    
+            <div className={styles.rowWrapper}>
                 {/* Set the row preview to be used during drag and drop */}
                 {connectDragPreview(
                     <div
                         className={styles.row +
                             (isDragging && isOver ? ` ${styles.rowLandingPad}` : '') +
-                            (isDragging && !!(isOver ^ canDrop) ? ` ${styles.rowCancelPad}` : '') +
+                            (isDragging && !!(isOver !== canDrop) ? ` ${styles.rowCancelPad}` : '') +
                             (isSearchMatch ? ` ${styles.rowSearchMatch}` : '') +
                             (isSearchFocus ? ` ${styles.rowSearchFocus}` : '') +
                             (className ? ` ${className}` : '')

--- a/src/utils/drag-and-drop-utils.js
+++ b/src/utils/drag-and-drop-utils.js
@@ -44,17 +44,7 @@ function getTargetDepth(dropTargetProps, monitor) {
         dropTargetProps.scaffoldBlockPxWidth
     );
 
-    let targetDepth = Math.min(dropTargetDepth, Math.max(0, draggedItem.path.length + blocksOffset - 1));
-
-    // If a maxDepth is defined, constrain the target depth
-    if (typeof dropTargetProps.maxDepth !== 'undefined' && dropTargetProps.maxDepth !== null) {
-        const draggedNode       = monitor.getItem().node;
-        const draggedChildDepth = getDepth(draggedNode);
-
-        targetDepth = Math.min(targetDepth, dropTargetProps.maxDepth - draggedChildDepth - 1);
-    }
-
-    return targetDepth;
+    return Math.min(dropTargetDepth, Math.max(0, draggedItem.path.length + blocksOffset - 1));
 }
 
 function canDrop(dropTargetProps, monitor, isHover = false) {
@@ -70,6 +60,16 @@ function canDrop(dropTargetProps, monitor, isHover = false) {
     const draggedNode = monitor.getItem().node;
     const parentPath = dropTargetProps.path.slice(0, -1);
     const parentNode = dropTargetProps.rows.find(row => row.path.toString() === parentPath.toString());
+
+    // If a maxDepth is defined, constrain the target depth
+    if (typeof dropTargetProps.maxDepth !== 'undefined' && dropTargetProps.maxDepth !== null) {
+        const draggedChildDepth = getDepth(draggedNode);
+
+        // Allow on hover, so we can display the red shadow
+        if (!isHover && targetDepth > dropTargetProps.maxDepth - draggedChildDepth - 1) {
+            return false;
+        }
+    }
 
     return (
         // Either we're not adding to the children of the row above...


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/fritz-c/react-sortable-tree/pull/32#issuecomment-271142424), showing the red shadow also when drag n drop is prevented by the `maxDepth` option to keep a consistent UX